### PR TITLE
using template literals in ch02

### DIFF
--- a/ch02/hello-js-world/js/script.js
+++ b/ch02/hello-js-world/js/script.js
@@ -3,7 +3,7 @@ class HelloWorld extends React.Component {
     return React.createElement(
       'h1',
       this.props,
-      'Hello ' + this.props.frameworkName + ' world!!!'
+      `Hello ${this.props.frameworkName}  world!!!`
     )
   }
 }


### PR DESCRIPTION
Hello!

I though  giving the `es6` and `es5` version of `ch02` example, templates literals should be included in the es6 version.

Cheers,  