### PR TITLE
adding babel-core to ch013/naive-router

### DIFF
--- a/ch13/naive-router/package.json
+++ b/ch13/naive-router/package.json
@@ -15,6 +15,7 @@
     ]
   },
   "devDependencies": {
+    "babel-core": "^6.18.2",
     "babel-loader": "^6.2.4",
     "babel-preset-react": "^6.5.0",
     "webpack": "1.12.9"


### PR DESCRIPTION
Hello ! 

when installing `naive-router` with `npm install` npm complains about missing libraries.

specifically about `babel-core`
``` bash
error: ➜  naive-router git:(master) npm install
naive-router@1.0.0 /Users/gago/work/tmp/react-quickly/ch13/naive-router
├── UNMET PEER DEPENDENCY babel-core@^6.0.0
├─┬ babel-loader@6.2.8
....
```
