### PR TITLE
Ch5 - Fixing console log messages in section (5.4)

### DIFF
--- a/ch05/logger/jsx/logger.jsx
+++ b/ch05/logger/jsx/logger.jsx
@@ -27,14 +27,14 @@ class Logger extends React.Component {
   }
   componentDidUpdate(oldProps, oldState) {
     console.log('componentDidUpdate is triggered')
-    console.log('new props: ', oldProps)
-    console.log('old props: ', oldState)
+    console.log('old props: ', oldProps)
+    console.log('old state: ', oldState)
   }
   componentWillUnmount() {
     console.log('componentWillUnmount')
   }
   render() {
-    // console.log('rendering... Display')
+    console.log('rendering... Display')
     return (
       <div>{this.props.time}</div>
     )


### PR DESCRIPTION
Old props in componentDidUpdate(...) were addressed as `new props` in the console logs.
Old state in componentDidUpdate(...) was addressed as `old props` in the console logs.
The `rendering... Display` message was commented out, if not showing in the console, I would rather get rid of it.