### PR TITLE
Method 'toLocaleString()' moved from state to child element (DigitalD…

### DIFF
--- a/ch04/clock-analog-digital/js/clock.js
+++ b/ch04/clock-analog-digital/js/clock.js
@@ -3,13 +3,13 @@ class Clock extends React.Component {
     super(props);
     this.launchClock();
     this.state = {
-      currentTime: new Date().toLocaleString()
+      currentTime: new Date()
     };
   }
   launchClock() {
     setInterval(() => {
       console.log('Updating...');
-      this.setState({ currentTime: new Date().toLocaleString() });
+      this.setState({ currentTime: new Date() });
     }, 1000);
   }
   render() {

--- a/ch04/clock-analog-digital/js/digital-display.js
+++ b/ch04/clock-analog-digital/js/digital-display.js
@@ -2,6 +2,6 @@ const DigitalDisplay = function (props) {
   return React.createElement(
     "div",
     null,
-    props.time
+    props.time.toLocaleString()
   );
 };

--- a/ch04/clock-analog-digital/jsx/clock.jsx
+++ b/ch04/clock-analog-digital/jsx/clock.jsx
@@ -3,13 +3,13 @@ class Clock extends React.Component {
     super(props)
     this.launchClock()
     this.state = {
-      currentTime: (new Date()).toLocaleString()
+      currentTime: new Date()
     }
   }
   launchClock() {
     setInterval(()=> {
       console.log('Updating...')
-      this.setState({currentTime: (new Date()).toLocaleString()})
+      this.setState({ currentTime: new Date() })
     }, 1000)
   }
   render() {

--- a/ch04/clock-analog-digital/jsx/digital-display.jsx
+++ b/ch04/clock-analog-digital/jsx/digital-display.jsx
@@ -1,3 +1,3 @@
 const DigitalDisplay = function(props) {
-  return <div>{props.time}</div>
+  return <div>{props.time.toLocaleString()}</div>
 }

--- a/ch04/clock/js/clock.js
+++ b/ch04/clock/js/clock.js
@@ -2,13 +2,13 @@ class Clock extends React.Component {
   constructor(props) {
     super(props);
     this.launchClock();
-    this.state = { currentTime: new Date().toLocaleString() };
+    this.state = { currentTime: new Date() };
   }
   launchClock() {
     setInterval(() => {
       console.log('Updating time...');
       this.setState({
-        currentTime: new Date().toLocaleString()
+        currentTime: new Date()
       });
     }, 1000);
   }

--- a/ch04/clock/jsx/clock.jsx
+++ b/ch04/clock/jsx/clock.jsx
@@ -2,13 +2,13 @@ class Clock extends React.Component {
   constructor(props) {
     super(props)
     this.launchClock()
-    this.state = {currentTime: (new Date()).toLocaleString()}
+    this.state = {currentTime: new Date()}
   }
   launchClock() {
     setInterval(()=> {
       console.log('Updating time...')
       this.setState({
-        currentTime: (new Date()).toLocaleString()
+        currentTime: new Date()
       })
     }, 1000)
   }


### PR DESCRIPTION
As i understand, if format of date differs from USA standards, in AnalogDisplay's component 'new Date(props.time)' will be output 'Invalid Date'. That's why animations of arrows will not working. CSS  property 'transform' will get NaN.

(At least with the Russian date format, such a problem exists.)

Local time formatting only in 'DigitalDisplay' - it's my solvetion of this problem.